### PR TITLE
add storageClassName: standard to pv/influxdb.yaml

### DIFF
--- a/pv/influxdb.yaml
+++ b/pv/influxdb.yaml
@@ -8,6 +8,7 @@ spec:
   accessModes:
     - ReadWriteOnce
   persistentVolumeReclaimPolicy: Retain
+  storageClassName: standard
   gcePersistentDisk:
     pdName: influxdb
     fsType: ext4


### PR DESCRIPTION
If this option is not specified, the volume and volumeClaim will be mismatched